### PR TITLE
Add HttpRequest type aliases for varying engine versions

### DIFF
--- a/Source/GameSwiftSdk/Private/RequestHandler.cpp
+++ b/Source/GameSwiftSdk/Private/RequestHandler.cpp
@@ -5,12 +5,18 @@
 
 
 #if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION <= 24
-TSharedRef<IHttpRequest> FRequestHandler::SendRequest(
+	using HttpRequestRef = TSharedRef<IHttpRequest>;
 #else
-TSharedRef<IHttpRequest, ESPMode::ThreadSafe> FRequestHandler::SendRequest(
+	using HttpRequestRef = TSharedRef<IHttpRequest, ESPMode::ThreadSafe>;
 #endif
-	FString FullUrl, FString Method, const FString callBody, const FString accessToken, bool ExpectsWwwResponse)
-{
+
+HttpRequestRef FRequestHandler::SendRequest(
+	FString FullUrl,
+	FString Method,
+	const FString& callBody,
+	const FString& accessToken,
+	bool ExpectsWwwResponse
+) {
 	auto HttpRequest = FHttpModule::Get().CreateRequest();
 	HttpRequest->SetVerb(Method);
 	HttpRequest->SetURL(FullUrl);

--- a/Source/GameSwiftSdk/Public/RequestHandler.h
+++ b/Source/GameSwiftSdk/Public/RequestHandler.h
@@ -11,12 +11,17 @@ class FRequestHandler
 {
 public:
 #if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION <= 24
-	static TSharedRef<IHttpRequest> SendRequest(
+	using HttpRequestRefType = TSharedRef<IHttpRequest>;
 #else
-	static TSharedRef<IHttpRequest, ESPMode::ThreadSafe> SendRequest(
+	using HttpRequestRefType = TSharedRef<IHttpRequest, ESPMode::ThreadSafe>;
 #endif
-		FString FullUrl, FString Method, const FString callBody, const FString accessToken,
-		bool ExpectsWwwResponse = false);
+	static HttpRequestRefType SendRequest(
+		const FString& FullUrl,
+		const FString& Method,
+		const FString& callBody,
+		const FString& accessToken,
+		bool ExpectsWwwResponse = false
+	);
 
 	static bool DecodeRequest(FHttpResponsePtr HttpResponse, bool bSucceeded, FJsonObject& ResultObject,
 	                          FBaseSdkFailResponse& OutError);


### PR DESCRIPTION
This section seems so tricky for me and could lead to readability issues. Consider using type aliases. This way, a single type name can be used throughout the code, and any changes would be confined only to the definition of that alias.